### PR TITLE
Avoid hidden path prefix for project configuration file

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -56,6 +56,6 @@ module.exports = {
     		 * @property {String} project - path to project config
     		 * @memberof paths
      */
-    project: path.join(process.cwd(), utils.addHiddenPathPrefix('resinrc.yml'))
+    project: path.join(process.cwd(), 'resinrc.yml')
   }
 };

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -50,4 +50,4 @@ module.exports =
 		# @property {String} project - path to project config
 		# @memberof paths
 		###
-		project: path.join(process.cwd(), utils.addHiddenPathPrefix('resinrc.yml'))
+		project: path.join(process.cwd(), 'resinrc.yml')


### PR DESCRIPTION
Windows and UNIX based systems have different hidden path prefixes (`_`
vs `.`) so this means the user has to duplicate the configuration file
to include both prefixes if his project wants to support multiple
platforms correctly.

In order to not force a specific hidden prefix (for consistency), we
make the path to the project configuration file non hidden.
