### PR TITLE
Add apiKeyVariable setting

### DIFF
--- a/build/defaults.js
+++ b/build/defaults.js
@@ -107,5 +107,11 @@ module.exports = {
   	 * @property {Number} tokenRefreshInterval - token refresh interval
   	 * @memberof defaults
    */
-  tokenRefreshInterval: 1 * 1000 * 60 * 60
+  tokenRefreshInterval: 1 * 1000 * 60 * 60,
+
+  /**
+  	 * @property {String} apiKeyVariable - api key environment variable
+  	 * @memberof defaults
+   */
+  apiKeyVariable: 'RESIN_API_KEY'
 };

--- a/lib/defaults.coffee
+++ b/lib/defaults.coffee
@@ -97,3 +97,9 @@ module.exports =
 	# @memberof defaults
 	###
 	tokenRefreshInterval: 1 * 1000 * 60 * 60 # 1 hour in milliseconds
+
+	###*
+	# @property {String} apiKeyVariable - api key environment variable
+	# @memberof defaults
+	###
+	apiKeyVariable: 'RESIN_API_KEY'

--- a/tests/defaults.spec.coffee
+++ b/tests/defaults.spec.coffee
@@ -110,3 +110,13 @@ describe 'Defaults:', ->
 		it 'should be an integer', ->
 			setting = utils.evaluateSetting(defaults, 'tokenRefreshInterval')
 			m.chai.expect(setting % 1).to.equal(0)
+
+	describe '.apiKeyVariable', ->
+
+		it 'should be a string', ->
+			setting = utils.evaluateSetting(defaults, 'apiKeyVariable')
+			m.chai.expect(setting).to.be.a('string')
+
+		it 'should not be empty', ->
+			setting = utils.evaluateSetting(defaults, 'apiKeyVariable')
+			m.chai.expect(setting.trim().length).to.not.equal(0)


### PR DESCRIPTION
This setting configures the name of the environment variable used to
find the saved API Key.

Partially implements: https://github.com/resin-io/resin-sdk/issues/143
