### PR TITLE
Interpret function settings on getAll()

### DIFF
--- a/build/settings.js
+++ b/build/settings.js
@@ -129,4 +129,8 @@ exports.get = function(name) {
  * settings.getAll()
  */
 
-exports.getAll = _.constant(settings);
+exports.getAll = function() {
+  return _.mapValues(settings, function(setting, name) {
+    return exports.get(name);
+  });
+};

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -119,4 +119,6 @@ exports.get = (name) ->
 # @example
 # settings.getAll()
 ###
-exports.getAll = _.constant(settings)
+exports.getAll = ->
+	return _.mapValues settings, (setting, name) ->
+		return exports.get(name)

--- a/tests/e2e/test.coffee
+++ b/tests/e2e/test.coffee
@@ -74,7 +74,12 @@ wary.it 'should be able to return all settings', {}, ->
 	process.env.RESINRC_DATA_DIRECTORY = '/opt'
 	m.chai.expect(getAll()).to.eventually.become
 		resinUrl: 'resindev.custom.com/'
+		apiUrl: 'https://api.resindev.custom.com/'
+		vpnUrl: 'vpn.resindev.custom.com/'
+		registryUrl: 'registry.resindev.custom.com/'
+		dashboardUrl: 'https://dashboard.resindev.custom.com/'
 		dataDirectory: '/opt'
+		cacheDirectory: path.join('/opt', 'cache')
 		projectsDirectory: '/usr/src/projects'
 		imageCacheTime: 604800000
 		tokenRefreshInterval: 3600000


### PR DESCRIPTION
Some settings are declared as functions which get their value
dynamically based on other settings.

These settings didn't work property when getting all settings with the
new `getAll()` function.
