### PR TITLE
Add deltaUrl default setting

### DIFF
--- a/build/defaults.js
+++ b/build/defaults.js
@@ -70,6 +70,14 @@ module.exports = {
   },
 
   /**
+  	 * @property {Function} deltaUrl - Resin.io Delta url
+  	 * @memberof defaults
+   */
+  deltaUrl: function() {
+    return "https://delta." + this.resinUrl;
+  },
+
+  /**
   	 * @property {Function} dashboardUrl - Resin.io dashboard url
   	 * @memberof defaults
    */

--- a/lib/defaults.coffee
+++ b/lib/defaults.coffee
@@ -60,6 +60,13 @@ module.exports =
 		return "https://img.#{@resinUrl}"
 
 	###*
+	# @property {Function} deltaUrl - Resin.io Delta url
+	# @memberof defaults
+	###
+	deltaUrl: ->
+		return "https://delta.#{@resinUrl}"
+
+	###*
 	# @property {Function} dashboardUrl - Resin.io dashboard url
 	# @memberof defaults
 	###

--- a/tests/defaults.spec.coffee
+++ b/tests/defaults.spec.coffee
@@ -66,6 +66,18 @@ describe 'Defaults:', ->
 			setting = utils.evaluateSetting(defaults, 'imageMakerUrl')
 			m.chai.expect(url.parse(setting).protocol).to.equal('https:')
 
+	describe '.deltaUrl', ->
+
+		it 'should be a valid url', ->
+			setting = utils.evaluateSetting(defaults, 'deltaUrl')
+			m.chai.expect ->
+				url.parse(setting)
+			.to.not.throw(Error)
+
+		it 'should contain an https protocol', ->
+			setting = utils.evaluateSetting(defaults, 'deltaUrl')
+			m.chai.expect(url.parse(setting).protocol).to.equal('https:')
+
 	describe '.dashboardUrl', ->
 
 		it 'should be a valid url', ->

--- a/tests/e2e/test.coffee
+++ b/tests/e2e/test.coffee
@@ -78,6 +78,7 @@ wary.it 'should be able to return all settings', {}, ->
 		vpnUrl: 'vpn.resindev.custom.com/'
 		registryUrl: 'registry.resindev.custom.com/'
 		imageMakerUrl: 'https://img.resindev.custom.com/'
+		deltaUrl: 'https://delta.resindev.custom.com/'
 		dashboardUrl: 'https://dashboard.resindev.custom.com/'
 		dataDirectory: '/opt'
 		cacheDirectory: path.join('/opt', 'cache')


### PR DESCRIPTION
This setting will then be used by `resin-device-config` to set the
`deltaEndpoint` `config.json` property.
