### PR TITLE
Add bin directory to resin settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+- Add bin directory to settings
+
 ## [3.5.2] - 2016-10-04
 
 - Update to `lodash` v4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ environment:
   matrix:
     - nodejs_version: 6
     - nodejs_version: 4
-    - nodejs_version: 0.12
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/build/defaults.js
+++ b/build/defaults.js
@@ -117,6 +117,14 @@ module.exports = {
   },
 
   /**
+  	 * @property {Function} binDirectory - binary directory path
+  	 * @memberof defaults
+   */
+  binDirectory: function() {
+    return path.join(this.dataDirectory, 'bin');
+  },
+
+  /**
   	 * @property {Number} imageCacheTime - image cache time
   	 * @memberof defaults
    */

--- a/lib/defaults.coffee
+++ b/lib/defaults.coffee
@@ -102,6 +102,13 @@ module.exports =
 		return path.join(@dataDirectory, 'cache')
 
 	###*
+	# @property {Function} binDirectory - binary directory path
+	# @memberof defaults
+	###
+	binDirectory: ->
+		return path.join(@dataDirectory, 'bin')
+
+	###*
 	# @property {Number} imageCacheTime - image cache time
 	# @memberof defaults
 	###

--- a/tests/e2e/test.coffee
+++ b/tests/e2e/test.coffee
@@ -89,6 +89,7 @@ wary.it 'should be able to return all settings', {}, ->
 		proxyUrl: 'devices.resindev.custom.com/'
 		dataDirectory: '/opt'
 		cacheDirectory: path.join('/opt', 'cache')
+		binDirectory: path.join('/opt', 'bin')
 		projectsDirectory: '/usr/src/projects'
 		imageCacheTime: 604800000
 		tokenRefreshInterval: 3600000


### PR DESCRIPTION
The bin directory will be used to store binaries used by resin-cli,
among other pieces of infrastructure.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@resin.io>