### PR TITLE
defaults: Add tunnelUrl to return a computed value

### DIFF
--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -102,6 +102,14 @@ export = {
 	},
 
 	/**
+	 * @property {Function} tunnelUrl - Balena Tunnel url
+	 * @memberof defaults
+	 */
+	tunnelUrl() {
+		return `tunnel.${this.balenaUrl}`;
+	},
+
+	/**
 	 * @property {String} dataDirectory - data directory path
 	 * @memberof defaults
 	 */

--- a/tests/defaults.spec.ts
+++ b/tests/defaults.spec.ts
@@ -114,6 +114,18 @@ describe('Defaults:', () => {
 		});
 	});
 
+	describe('.tunnelUrl', () => {
+		it('should be a valid url', () => {
+			const setting = utils.evaluateSetting<string>(defaults, 'tunnelUrl');
+			expect(() => url.parse(setting)).to.not.throw(Error);
+		});
+
+		it('should not contain a protocol', () => {
+			const setting = utils.evaluateSetting<string>(defaults, 'tunnelUrl');
+			expect(url.parse(setting).protocol).to.not.exist;
+		});
+	});
+
 	describe('.dataDirectory', () =>
 		it('should be an absolute path', () => {
 			const setting = utils.evaluateSetting<string>(defaults, 'dataDirectory');

--- a/tests/e2e/test.ts
+++ b/tests/e2e/test.ts
@@ -172,6 +172,7 @@ wary.it('should be able to return all settings', {}, () => {
 		deltaUrl: 'https://delta.balenadev.custom.com/',
 		dashboardUrl: 'https://dashboard.balenadev.custom.com/',
 		proxyUrl: 'devices.balenadev.custom.com/',
+		tunnelUrl: 'tunnel.balenadev.custom.com/',
 		dataDirectory: '/opt',
 		cacheDirectory: path.join('/opt', 'cache'),
 		binDirectory: path.join('/opt', 'bin'),


### PR DESCRIPTION
Expose the Url a client should use to access the tunnel service for
their devices.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>